### PR TITLE
Change vendor name from writingink to themsaid in migration command

### DIFF
--- a/src/Console/MigrateCommand.php
+++ b/src/Console/MigrateCommand.php
@@ -37,7 +37,7 @@ class MigrateCommand extends Command
 
         $this->call('migrate', [
             '--database' => config('wink.database_connection'),
-            '--path' => 'vendor/writingink/wink/src/Migrations',
+            '--path' => 'vendor/themsaid/wink/src/Migrations',
         ]);
 
         if ($shouldCreateNewAuthor) {


### PR DESCRIPTION
Fixing issue #250 

I have faced the same issue as mentioned and found that you have just recently moved the repo under themsaid but the migrations still try to run from the old repo "writingink" 