### PR TITLE
Fix Team missing pagination

### DIFF
--- a/src/Http/Controllers/TeamController.php
+++ b/src/Http/Controllers/TeamController.php
@@ -22,7 +22,7 @@ class TeamController
         })
             ->orderBy('created_at', 'DESC')
             ->withCount('posts')
-            ->get();
+            ->paginate(30);
 
         return TeamResource::collection($entries);
     }


### PR DESCRIPTION
Because the team endpoint does not using pagination. the JS load entities throws an exception `data.links` object is not defined

<img width="661" alt="paginate-wink" src="https://user-images.githubusercontent.com/8272048/82153594-a2964800-9868-11ea-92d5-df952f04c049.png">

applying pagination 30 like in posts should solve the problem