### PR TITLE
Configurable tables

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,11 @@
 {
     "name": "themsaid/wink",
     "description": "Wink Publishing Framework.",
-    "keywords": ["framework", "laravel", "blog"],
+    "keywords": [
+        "framework",
+        "laravel",
+        "blog"
+    ],
     "license": "MIT",
     "authors": [
         {

--- a/config/wink.php
+++ b/config/wink.php
@@ -78,7 +78,7 @@ return [
 
     'preview_path' => '/{postSlug}',
 
-    'table_name' => [
+    'table_names' => [
         'wink_authors' => 'wink_authors',
         'wink_pages' => 'wink_pages',
         'wink_posts' => 'wink_posts',

--- a/config/wink.php
+++ b/config/wink.php
@@ -85,10 +85,4 @@ return [
         'wink_posts_tags' => 'wink_posts_tags',
         'wink_tags' => 'wink_tags',
     ],
-    'column_names' => [
-        'author_id' => 'author_id'
-    ],
-    'models' => [
-        'author' => 'Wink\WinkAuthor'
-    ]
 ];

--- a/config/wink.php
+++ b/config/wink.php
@@ -77,4 +77,18 @@ return [
     */
 
     'preview_path' => '/{postSlug}',
+
+    'table_name' => [
+        'wink_authors' => 'wink_authors',
+        'wink_pages' => 'wink_pages',
+        'wink_posts' => 'wink_posts',
+        'wink_posts_tags' => 'wink_posts_tags',
+        'wink_tags' => 'wink_tags',
+    ],
+    'column_names' => [
+        'author_id' => 'author_id'
+    ],
+    'models' => [
+        'author' => 'Wink\WinkAuthor'
+    ]
 ];

--- a/src/Console/MigrateCommand.php
+++ b/src/Console/MigrateCommand.php
@@ -33,8 +33,8 @@ class MigrateCommand extends Command
     public function handle()
     {
         $shouldCreateNewAuthor =
-            ! Schema::connection(config('wink.database_connection'))->hasTable('wink_authors') ||
-            ! WinkAuthor::count();
+            !Schema::connection(config('wink.database_connection'))->hasTable('wink_authors') ||
+            !WinkAuthor::count();
 
         $this->call('migrate', [
             '--database' => config('wink.database_connection'),
@@ -43,8 +43,8 @@ class MigrateCommand extends Command
         ]);
 
         if ($shouldCreateNewAuthor) {
-            $email = ! $this->argument('email') ? 'admin@mail.com' : $this->argument('email');
-            $password = ! $this->argument('password') ? Str::random() : $this->argument('password');
+            $email = !$this->argument('email') ? 'admin@mail.com' : $this->argument('email');
+            $password = !$this->argument('password') ? Str::random() : $this->argument('password');
 
             WinkAuthor::create([
                 'id' => (string) Str::uuid(),
@@ -58,7 +58,7 @@ class MigrateCommand extends Command
             $this->line('');
             $this->line('');
             $this->line('Wink is ready for use. Enjoy!');
-            $this->line('You may log in using <info>'.$email.'</info> and password: <info>'.$password.'</info>');
+            $this->line('You may log in using <info>' . $email . '</info> and password: <info>' . $password . '</info>');
         }
     }
 }

--- a/src/Http/Controllers/PagesController.php
+++ b/src/Http/Controllers/PagesController.php
@@ -17,7 +17,7 @@ class PagesController
     public function index()
     {
         $entries = WinkPage::when(request()->has('search'), function ($q) {
-            $q->where('title', 'LIKE', '%'.request('search').'%');
+            $q->where('title', 'LIKE', '%' . request('search') . '%');
         })
             ->orderBy('created_at', 'DESC')
             ->paginate(30);
@@ -63,7 +63,7 @@ class PagesController
 
         validator($data, [
             'title' => 'required',
-            'slug' => 'required|'.Rule::unique(config('wink.database_connection').'.wink_pages', 'slug')->ignore(request('id')),
+            'slug' => 'required|' . Rule::unique(config('wink.database_connection') . '.' . config('wink.table_names.wink_pages', 'wink_pages'), 'slug')->ignore(request('id')),
         ])->validate();
 
         $entry = $id !== 'new' ? WinkPage::findOrFail($id) : new WinkPage(['id' => request('id')]);

--- a/src/Http/Controllers/PostsController.php
+++ b/src/Http/Controllers/PostsController.php
@@ -18,7 +18,7 @@ class PostsController
     public function index()
     {
         $entries = WinkPost::when(request()->has('search'), function ($q) {
-            $q->where('title', 'LIKE', '%'.request('search').'%');
+            $q->where('title', 'LIKE', '%' . request('search') . '%');
         })->when(request('status'), function ($q, $value) {
             $q->$value();
         })->when(request('author_id'), function ($q, $value) {
@@ -86,7 +86,7 @@ class PostsController
             'publish_date' => 'required|date',
             'author_id' => 'required',
             'title' => 'required',
-            'slug' => 'required|'.Rule::unique(config('wink.database_connection').'.wink_posts', 'slug')->ignore(request('id')),
+            'slug' => 'required|' . Rule::unique(config('wink.database_connection') . '.' . config('wink.table_names.wink_posts', 'wink_posts'), 'slug')->ignore(request('id')),
         ])->validate();
 
         $entry = $id !== 'new' ? WinkPost::findOrFail($id) : new WinkPost(['id' => request('id')]);
@@ -117,7 +117,7 @@ class PostsController
         return collect($incomingTags)->map(function ($incomingTag) use ($allTags) {
             $tag = $allTags->where('id', $incomingTag['id'])->first();
 
-            if (! $tag) {
+            if (!$tag) {
                 $tag = WinkTag::create([
                     'id' => $id = Str::uuid(),
                     'name' => $incomingTag['name'],

--- a/src/Http/Controllers/TagsController.php
+++ b/src/Http/Controllers/TagsController.php
@@ -17,7 +17,7 @@ class TagsController
     public function index()
     {
         $entries = WinkTag::when(request()->has('search'), function ($q) {
-            $q->where('name', 'LIKE', '%'.request('search').'%');
+            $q->where('name', 'LIKE', '%' . request('search') . '%');
         })
             ->orderBy('created_at', 'DESC')
             ->withCount('posts')
@@ -65,7 +65,7 @@ class TagsController
 
         validator($data, [
             'name' => 'required',
-            'slug' => 'required|'.Rule::unique(config('wink.database_connection').'.wink_tags', 'slug')->ignore(request('id')),
+            'slug' => 'required|' . Rule::unique(config('wink.database_connection') . '.' . config('wink.table_names.wink_tags', 'wink_tags'), 'slug')->ignore(request('id')),
         ])->validate();
 
         $entry = $id !== 'new' ? WinkTag::findOrFail($id) : new WinkTag(['id' => request('id')]);

--- a/src/Http/Controllers/TeamController.php
+++ b/src/Http/Controllers/TeamController.php
@@ -18,7 +18,7 @@ class TeamController
     public function index()
     {
         $entries = WinkAuthor::when(request()->has('search'), function ($q) {
-            $q->where('name', 'LIKE', '%'.request('search').'%');
+            $q->where('name', 'LIKE', '%' . request('search') . '%');
         })
             ->orderBy('created_at', 'DESC')
             ->withCount('posts')
@@ -70,8 +70,8 @@ class TeamController
         validator($data, [
             'meta.theme' => 'in:dark,light',
             'name' => 'required',
-            'slug' => 'required|'.Rule::unique(config('wink.database_connection').'.wink_authors', 'slug')->ignore(request('id')),
-            'email' => 'required|email|'.Rule::unique(config('wink.database_connection').'.wink_authors', 'email')->ignore(request('id')),
+            'slug' => 'required|' . Rule::unique(config('wink.database_connection') . '.' . config('wink.table_names.wink_authors', 'wink_authors'), 'slug')->ignore(request('id')),
+            'email' => 'required|email|' . Rule::unique(config('wink.database_connection') . '.' . config('wink.table_names.wink_authors', 'wink_authors'), 'email')->ignore(request('id')),
         ])->validate();
 
         $entry = $id !== 'new' ? WinkAuthor::findOrFail($id) : new WinkAuthor(['id' => request('id')]);

--- a/src/Migrations/2018_10_30_000000_create_tables.php
+++ b/src/Migrations/2018_10_30_000000_create_tables.php
@@ -71,10 +71,10 @@ class CreateTables extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('wink_tags');
-        Schema::dropIfExists('wink_posts_tags');
-        Schema::dropIfExists('wink_authors');
-        Schema::dropIfExists('wink_posts');
-        Schema::dropIfExists('wink_pages');
+        Schema::dropIfExists(config('wink.table_names.wink_tags', 'wink_tags'));
+        Schema::dropIfExists(config('wink.table_names.wink_posts_tags', 'wink_posts_tags'));
+        Schema::dropIfExists(config('wink.table_names.wink_authors', 'wink_authors'));
+        Schema::dropIfExists(config('wink.table_names.wink_posts', 'wink_posts'));
+        Schema::dropIfExists(config('wink.table_names.wink_pages', 'wink_pages'));
     }
 }

--- a/src/Migrations/2018_10_30_000000_create_tables.php
+++ b/src/Migrations/2018_10_30_000000_create_tables.php
@@ -13,7 +13,7 @@ class CreateTables extends Migration
      */
     public function up()
     {
-        Schema::create('wink_tags', function (Blueprint $table) {
+        Schema::create(config('wink.table_names.wink_tags', 'wink_tags'), function (Blueprint $table) {
             $table->uuid('id')->primary();
             $table->string('slug')->unique();
             $table->string('name');
@@ -22,14 +22,14 @@ class CreateTables extends Migration
             $table->index('created_at');
         });
 
-        Schema::create('wink_posts_tags', function (Blueprint $table) {
+        Schema::create(config('wink.table_names.wink_posts_tags', 'wink_posts_tags'), function (Blueprint $table) {
             $table->uuid('post_id');
             $table->uuid('tag_id');
 
             $table->unique(['post_id', 'tag_id']);
         });
 
-        Schema::create('wink_posts', function (Blueprint $table) {
+        Schema::create(config('wink.table_names.wink_posts', 'wink_posts'), function (Blueprint $table) {
             $table->uuid('id')->primary();
             $table->string('slug')->unique();
             $table->string('title');
@@ -43,7 +43,7 @@ class CreateTables extends Migration
             $table->timestamps();
         });
 
-        Schema::create('wink_authors', function (Blueprint $table) {
+        Schema::create(config('wink.table_names.wink_authors', 'wink_authors'), function (Blueprint $table) {
             $table->uuid('id')->primary();
             $table->string('slug')->unique();
             $table->string('name');
@@ -55,7 +55,7 @@ class CreateTables extends Migration
             $table->timestamps();
         });
 
-        Schema::create('wink_pages', function (Blueprint $table) {
+        Schema::create(config('wink.table_names.wink_pages', 'wink_pages'), function (Blueprint $table) {
             $table->uuid('id')->primary();
             $table->string('slug')->unique();
             $table->string('title');

--- a/src/Migrations/2018_11_16_000000_add_meta_fields.php
+++ b/src/Migrations/2018_11_16_000000_add_meta_fields.php
@@ -13,19 +13,19 @@ class AddMetaFields extends Migration
      */
     public function up()
     {
-        Schema::table('wink_tags', function (Blueprint $table) {
+        Schema::table(config('wink.table_names.wink_tags', 'wink_tags'), function (Blueprint $table) {
             $table->text('meta')->nullable();
         });
 
-        Schema::table('wink_pages', function (Blueprint $table) {
+        Schema::table(config('wink.table_names.wink_pages', 'wink_pages'), function (Blueprint $table) {
             $table->text('meta')->nullable();
         });
 
-        Schema::table('wink_authors', function (Blueprint $table) {
+        Schema::table(config('wink.table_names.wink_authors', 'wink_authors'), function (Blueprint $table) {
             $table->text('meta')->nullable();
         });
 
-        Schema::table('wink_posts', function (Blueprint $table) {
+        Schema::table(config('wink.table_names.wink_posts', 'wink_posts'), function (Blueprint $table) {
             $table->text('meta')->nullable();
         });
     }
@@ -37,19 +37,19 @@ class AddMetaFields extends Migration
      */
     public function down()
     {
-        Schema::table('wink_tags', function (Blueprint $table) {
+        Schema::table(config('wink.table_names.wink_tags', 'wink_tags'), function (Blueprint $table) {
             $table->dropColumn('meta');
         });
 
-        Schema::table('wink_pages', function (Blueprint $table) {
+        Schema::table(config('wink.table_names.wink_pages', 'wink_pages'), function (Blueprint $table) {
             $table->dropColumn('meta');
         });
 
-        Schema::table('wink_authors', function (Blueprint $table) {
+        Schema::table(config('wink.table_names.wink_authors', 'wink_authors'), function (Blueprint $table) {
             $table->dropColumn('meta');
         });
 
-        Schema::table('wink_posts', function (Blueprint $table) {
+        Schema::table(config('wink.table_names.wink_posts', 'wink_posts'), function (Blueprint $table) {
             $table->dropColumn('meta');
         });
     }

--- a/src/Migrations/2020_05_17_000000_add_markdown_field.php
+++ b/src/Migrations/2020_05_17_000000_add_markdown_field.php
@@ -13,7 +13,7 @@ class AddMarkdownField extends Migration
      */
     public function up()
     {
-        Schema::table('wink_posts', function (Blueprint $table) {
+        Schema::table(config('wink.table_names.wink_posts', 'wink_posts'), function (Blueprint $table) {
             $table->boolean('markdown')->default(false);
         });
     }
@@ -25,8 +25,8 @@ class AddMarkdownField extends Migration
      */
     public function down()
     {
-        Schema::table('wink_posts', function (Blueprint $table) {
-            $table->boolean('markdown')->default(false);
+        Schema::table(config('wink.table_names.wink_posts', 'wink_posts'), function (Blueprint $table) {
+            $table->dropColumn('markdown');
         });
     }
 }

--- a/src/WinkAuthor.php
+++ b/src/WinkAuthor.php
@@ -21,13 +21,6 @@ class WinkAuthor extends AbstractWinkModel implements Authenticatable
     protected $hidden = ['password', 'remember_token'];
 
     /**
-     * The table associated with the model.
-     *
-     * @var string
-     */
-    protected $table = 'wink_authors';
-
-    /**
      * The primary key for the model.
      *
      * @var string
@@ -63,6 +56,12 @@ class WinkAuthor extends AbstractWinkModel implements Authenticatable
     protected $casts = [
         'meta' => 'array',
     ];
+
+    public function __construct()
+    {
+        //parent::__construct();
+        $this->setTable(config('wink.table_names.wink_authors', 'wink_authors'));
+    }
 
     /**
      * The posts.
@@ -111,7 +110,7 @@ class WinkAuthor extends AbstractWinkModel implements Authenticatable
      */
     public function getRememberToken()
     {
-        if (! empty($this->getRememberTokenName())) {
+        if (!empty($this->getRememberTokenName())) {
             return (string) $this->{$this->getRememberTokenName()};
         }
     }
@@ -124,7 +123,7 @@ class WinkAuthor extends AbstractWinkModel implements Authenticatable
      */
     public function setRememberToken($value)
     {
-        if (! empty($this->getRememberTokenName())) {
+        if (!empty($this->getRememberTokenName())) {
             $this->{$this->getRememberTokenName()} = $value;
         }
     }
@@ -147,6 +146,6 @@ class WinkAuthor extends AbstractWinkModel implements Authenticatable
      */
     public function getAvatarAttribute($value)
     {
-        return $value ?: 'https://secure.gravatar.com/avatar/'.md5(strtolower(trim($this->email))).'?s=80';
+        return $value ?: 'https://secure.gravatar.com/avatar/' . md5(strtolower(trim($this->email))) . '?s=80';
     }
 }

--- a/src/WinkAuthor.php
+++ b/src/WinkAuthor.php
@@ -57,9 +57,9 @@ class WinkAuthor extends AbstractWinkModel implements Authenticatable
         'meta' => 'array',
     ];
 
-    public function __construct()
+    public function __construct($attributes = [])
     {
-        //parent::__construct();
+        parent::__construct($attributes);
         $this->setTable(config('wink.table_names.wink_authors', 'wink_authors'));
     }
 
@@ -146,6 +146,6 @@ class WinkAuthor extends AbstractWinkModel implements Authenticatable
      */
     public function getAvatarAttribute($value)
     {
-        return $value ?: 'https://secure.gravatar.com/avatar/' . md5(strtolower(trim($this->email))) . '?s=80';
+        return $value ?: 'https://secure.gravatar.com/avatar/' . md5(strtolower(trim($this->email))) . '?s=80&d=mp';
     }
 }

--- a/src/WinkPage.php
+++ b/src/WinkPage.php
@@ -50,6 +50,12 @@ class WinkPage extends AbstractWinkModel
         'meta' => 'array',
     ];
 
+    public function __construct()
+    {
+        //parent::__construct();
+        $this->setTable(config('wink.table_names.wink_pages', 'wink_pages'));
+    }
+
     /**
      * Get the renderable page content.
      *

--- a/src/WinkPage.php
+++ b/src/WinkPage.php
@@ -12,13 +12,6 @@ class WinkPage extends AbstractWinkModel
     protected $guarded = [];
 
     /**
-     * The table associated with the model.
-     *
-     * @var string
-     */
-    protected $table = 'wink_pages';
-
-    /**
      * The primary key for the model.
      *
      * @var string
@@ -50,9 +43,9 @@ class WinkPage extends AbstractWinkModel
         'meta' => 'array',
     ];
 
-    public function __construct()
+    public function __construct($attributes = [])
     {
-        //parent::__construct();
+        parent::__construct($attributes);
         $this->setTable(config('wink.table_names.wink_pages', 'wink_pages'));
     }
 

--- a/src/WinkPost.php
+++ b/src/WinkPost.php
@@ -63,6 +63,12 @@ class WinkPost extends AbstractWinkModel
         'markdown' => 'boolean',
     ];
 
+    public function __construct()
+    {
+        //parent::__construct();
+        $this->setTable(config('wink.table_names.wink_posts', 'wink_posts'));
+    }
+
     /**
      * The tags the post belongs to.
      *
@@ -70,7 +76,7 @@ class WinkPost extends AbstractWinkModel
      */
     public function tags()
     {
-        return $this->belongsToMany(WinkTag::class, 'wink_posts_tags', 'post_id', 'tag_id');
+        return $this->belongsToMany(WinkTag::class, config('wink.table_names.wink_posts_tags', 'wink_posts_tags'), 'post_id', 'tag_id');
     }
 
     /**
@@ -90,7 +96,7 @@ class WinkPost extends AbstractWinkModel
      */
     public function getContentAttribute()
     {
-        if (! $this->markdown) {
+        if (!$this->markdown) {
             return $this->body;
         }
 

--- a/src/WinkPost.php
+++ b/src/WinkPost.php
@@ -16,13 +16,6 @@ class WinkPost extends AbstractWinkModel
     protected $guarded = [];
 
     /**
-     * The table associated with the model.
-     *
-     * @var string
-     */
-    protected $table = 'wink_posts';
-
-    /**
      * The primary key for the model.
      *
      * @var string
@@ -63,9 +56,9 @@ class WinkPost extends AbstractWinkModel
         'markdown' => 'boolean',
     ];
 
-    public function __construct()
+    public function __construct($attributes = [])
     {
-        //parent::__construct();
+        parent::__construct($attributes);
         $this->setTable(config('wink.table_names.wink_posts', 'wink_posts'));
     }
 

--- a/src/WinkServiceProvider.php
+++ b/src/WinkServiceProvider.php
@@ -20,8 +20,10 @@ class WinkServiceProvider extends ServiceProvider
         $this->registerPublishing();
 
         $this->loadViewsFrom(
-            __DIR__.'/../resources/views', 'wink'
+            __DIR__ . '/../resources/views',
+            'wink'
         );
+        $this->loadMigrationsFrom(__DIR__ . '/../src/Migrations');
     }
 
     /**
@@ -53,7 +55,7 @@ class WinkServiceProvider extends ServiceProvider
             ->domain(config('wink.domain'))
             ->prefix(config('wink.path'))
             ->group(function () {
-                $this->loadRoutesFrom(__DIR__.'/Http/routes.php');
+                $this->loadRoutesFrom(__DIR__ . '/Http/routes.php');
             });
     }
 
@@ -84,12 +86,20 @@ class WinkServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->publishes([
-                __DIR__.'/../public' => public_path('vendor/wink'),
+                __DIR__ . '/../public' => public_path('vendor/wink'),
             ], 'wink-assets');
 
             $this->publishes([
-                __DIR__.'/../config/wink.php' => config_path('wink.php'),
+                __DIR__ . '/../config/wink.php' => config_path('wink.php'),
             ], 'wink-config');
+
+            $this->publishes([
+                __DIR__ . '/../resources/views' => resource_path('views/vendor/wink'),
+            ], 'wink-views');
+
+            $this->publishes([
+                __DIR__ . '/../src/Migrations/' => database_path('migrations'),
+            ], 'wink-migrations');
         }
     }
 
@@ -101,7 +111,8 @@ class WinkServiceProvider extends ServiceProvider
     public function register()
     {
         $this->mergeConfigFrom(
-            __DIR__.'/../config/wink.php', 'wink'
+            __DIR__ . '/../config/wink.php',
+            'wink'
         );
 
         $this->commands([

--- a/src/WinkTag.php
+++ b/src/WinkTag.php
@@ -48,6 +48,12 @@ class WinkTag extends AbstractWinkModel
         'meta' => 'array',
     ];
 
+    public function __construct()
+    {
+        //parent::__construct();
+        $this->setTable(config('wink.table_names.wink_tags', 'wink_tags'));
+    }
+
     /**
      * The posts that has the tag.
      *
@@ -55,7 +61,7 @@ class WinkTag extends AbstractWinkModel
      */
     public function posts()
     {
-        return $this->belongsToMany(WinkPost::class, 'wink_posts_tags', 'tag_id', 'post_id');
+        return $this->belongsToMany(WinkTag::class, config('wink.table_names.wink_posts_tags', 'wink_posts_tags'), 'tag_id', 'post_id');
     }
 
     /**

--- a/src/WinkTag.php
+++ b/src/WinkTag.php
@@ -12,13 +12,6 @@ class WinkTag extends AbstractWinkModel
     protected $guarded = [];
 
     /**
-     * The table associated with the model.
-     *
-     * @var string
-     */
-    protected $table = 'wink_tags';
-
-    /**
      * The primary key for the model.
      *
      * @var string
@@ -48,9 +41,9 @@ class WinkTag extends AbstractWinkModel
         'meta' => 'array',
     ];
 
-    public function __construct()
+    public function __construct($attributes = [])
     {
-        //parent::__construct();
+        parent::__construct($attributes);
         $this->setTable(config('wink.table_names.wink_tags', 'wink_tags'));
     }
 


### PR DESCRIPTION
Allows to configure table names.

Gives you control the control to name wink tables using the `config/wink.php` file.

Now you have the option to use `php artisan wink:install && php artisan wink:migrate` or
use regular `php artisan migrate && php artisan vendor:publish` depending wish one you prefer, that way you can have more control.
