### PR TITLE
Remove larastan because the version conflicts with the Laravel version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,6 @@
         "php": "^7.3",
         "laravel/framework": "~7.0"
     },
-    "require-dev": {
-        "nunomaduro/larastan": "^0.3.8"
-    },
     "autoload": {
         "psr-4": {
             "Wink\\": "src/"


### PR DESCRIPTION
While pulling the project and running a composer install for another PR I found out that the required larastan version conflicts with the Laravel version.

Because I didn't found any place where it is used I think it is a good idea to remove it. Else the version need to be changed.