### PR TITLE
Add image pasting functionality to markdown editor

### DIFF
--- a/resources/js/components/MarkdownEditor.vue
+++ b/resources/js/components/MarkdownEditor.vue
@@ -98,8 +98,24 @@ export default {
         insertAtCursor(text) {
             this.textarea.focus();
 
-            document.execCommand("insertText", false /*no UI*/, text);
-            this.content = this.textarea.value;
+            const isSuccessful = document.execCommand(
+                "insertText",
+                false,
+                text
+            );
+
+            // Firefox (non-standard method)
+            if (!isSuccessful && typeof input.setRangeText === "function") {
+                const start = input.selectionStart;
+                input.setRangeText(text);
+                // update cursor to be at the end of insertion
+                input.selectionStart = input.selectionEnd = start + text.length;
+
+                // Notify any possible listeners of the change
+                const e = document.createEvent("UIEvent");
+                e.initEvent("input", true, false);
+                input.dispatchEvent(e);
+            }
         },
         insertImage(placeholder, url) {
             this.content = this.content.replace(

--- a/resources/js/components/MarkdownEditor.vue
+++ b/resources/js/components/MarkdownEditor.vue
@@ -1,58 +1,114 @@
 <script type="text/ecmascript">
-    import _ from 'lodash';
+import _ from "lodash";
 
-    export default {
-        props: {
-            value: {
-                type: String,
-                default: ''
-            },
-        },
+export default {
+    props: {
+        value: {
+            type: String,
+            default: ""
+        }
+    },
 
+    data() {
+        return {
+            textarea: null,
+            content: "",
+            uploadProgress: 0,
+            uploading: false
+        };
+    },
 
-        data() {
-            return {
-                content: ''
+    watch: {
+        content(val) {
+            this.$emit("input", val);
+        }
+    },
+
+    mounted() {
+        this.content = this.value;
+
+        this.$nextTick(() => {
+            this.textarea = document.getElementById("markdown-editor");
+            var heightLimit = 2000;
+
+            this.textarea.style.height =
+                Math.min(this.textarea.scrollHeight, heightLimit) + "px";
+
+            if (this.textarea) {
+                this.textarea.style.height =
+                    Math.min(this.textarea.scrollHeight, heightLimit) + "px";
+
+                this.textarea.oninput = function() {
+                    this.textarea.style.height = "";
+                    this.textarea.style.height =
+                        Math.min(this.textarea.scrollHeight, heightLimit) +
+                        "px";
+                };
+
+                this.textarea.addEventListener("paste", this.onPaste);
             }
-        },
+        });
+    },
 
-        watch: {
-            content(val) {
-                this.$emit('input', val);
-            }
-        },
+    destroyed() {
+        if (this.textarea) {
+            this.textarea.removeEventListener("paste", this.onPaste);
+        }
+    },
 
-
-        mounted() {
-            this.content = this.value;
-
-            this.$nextTick(() => {
-                var textarea = document.getElementById("markdown-editor");
-                var heightLimit = 2000;
-
-                textarea.style.height = Math.min(textarea.scrollHeight, heightLimit) + "px";
-
-                if (textarea) {
-                    textarea.style.height = Math.min(textarea.scrollHeight, heightLimit) + "px";
-
-                    textarea.oninput = function () {
-                        textarea.style.height = "";
-                        textarea.style.height = Math.min(textarea.scrollHeight, heightLimit) + "px";
-                    };
+    methods: {
+        onPaste(e) {
+            if (e.clipboardData && e.clipboardData.items) {
+                var items = e.clipboardData.items;
+                for (var i = 0; i < items.length; i++) {
+                    if (items[i].type.indexOf("image") !== -1) {
+                        const image = items[i].getAsFile();
+                        this.uploadPastedImage(image);
+                        e.preventDefault();
+                    }
                 }
-            });
+            }
         },
 
+        uploadPastedImage(image) {
+            let formData = new FormData();
 
-        methods: {}
+            formData.append("image", image, image.name);
+
+            const placeholder = `![Uploading ${image.name}…]()`;
+
+            this.content = this.content.concat(placeholder);
+
+            this.http()
+                .post("/api/uploads", formData, {
+                    onUploadProgress: progressEvent => {
+                        this.uploadProgress = Math.round(
+                            (progressEvent.loaded * 100) / progressEvent.total
+                        );
+                    }
+                })
+                .then(({ data }) => {
+                    this.insertImage(placeholder, data.url);
+                })
+                .catch(error => {
+                    console.log(error);
+                });
+        },
+        insertImage(placeholder, url) {
+            this.content = this.content.replace(
+                placeholder,
+                `![alt text](${url} "alt text)`
+            );
+        }
     }
+};
 </script>
 
 <template>
     <div>
        <textarea id="markdown-editor"
                  spellcheck="false"
-                 class="w-full outline-none resize-none text-sm leading-loose font-mono"
+                 class="w-full font-mono text-sm leading-loose outline-none resize-none"
                  cols="30" rows="10" v-model="content"
                  placeholder="Start writing *now*"></textarea>
     </div>

--- a/resources/js/components/MarkdownEditor.vue
+++ b/resources/js/components/MarkdownEditor.vue
@@ -14,7 +14,6 @@ export default {
             textarea: null,
             content: "",
             uploadProgress: 0,
-            uploading: false
         };
     },
 

--- a/resources/js/components/MarkdownEditor.vue
+++ b/resources/js/components/MarkdownEditor.vue
@@ -14,6 +14,7 @@ export default {
             textarea: null,
             content: "",
             uploadProgress: 0,
+            uploading: false
         };
     },
 
@@ -37,7 +38,7 @@ export default {
                 this.textarea.style.height =
                     Math.min(this.textarea.scrollHeight, heightLimit) + "px";
 
-                this.textarea.oninput = function() {
+                this.textarea.oninput = () => {
                     this.textarea.style.height = "";
                     this.textarea.style.height =
                         Math.min(this.textarea.scrollHeight, heightLimit) +
@@ -76,7 +77,7 @@ export default {
 
             const placeholder = `![Uploading ${image.name}…]()`;
 
-            this.content = this.content.concat(placeholder);
+            this.insertAtCursor(placeholder);
 
             this.http()
                 .post("/api/uploads", formData, {
@@ -92,6 +93,13 @@ export default {
                 .catch(error => {
                     console.log(error);
                 });
+        },
+
+        insertAtCursor(text) {
+            this.textarea.focus();
+
+            document.execCommand("insertText", false /*no UI*/, text);
+            this.content = this.textarea.value;
         },
         insertImage(placeholder, url) {
             this.content = this.content.replace(


### PR DESCRIPTION
This PR adds very simple image uploading ability to the Wink markdown editor. 
The functionality is mean to mimic the github markdown editor as seen in the gif below.
This also lets you insert (paste) the image at your cursor position.
I'm using bananas for scale to illustrate the functionality.

![banans-for-scale](https://user-images.githubusercontent.com/228899/89746997-91c52f00-da71-11ea-8271-8178547d0393.gif)

![Ee1rIMlXsAEUjwq](https://user-images.githubusercontent.com/228899/89747008-a30e3b80-da71-11ea-953f-7b775c24ee1b.png)



