### PR TITLE
Laravel 8 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.3||^7.4",
-        "laravel/framework": "~7.0"
+        "laravel/framework": "^7.0|^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.3||^7.4",
-        "laravel/framework": "^7.0|^8.0"
+        "laravel/framework": "^7.0||^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -22,9 +22,9 @@ Route::delete('/api/tags/{id}', [TagsController::class, 'delete'])->name('tags.d
 
 // Blog Authors...
 Route::get('/api/team', [TeamController::class, 'index'])->name('team.index');
-Route::get('/api/team/{id?}', [TagsController::class, 'show'])->name('team.show');
-Route::post('/api/team/{id}', [TagsController::class, 'store'])->name('team.store');
-Route::delete('/api/team/{id}', [TagsController::class, 'delete'])->name('team.delete');
+Route::get('/api/team/{id?}', [TeamController::class, 'show'])->name('team.show');
+Route::post('/api/team/{id}', [TeamController::class, 'store'])->name('team.store');
+Route::delete('/api/team/{id}', [TeamController::class, 'delete'])->name('team.delete');
 
 // Blog Image Uploads
 Route::post('/api/uploads', [ImageUploadsController::class, 'upload'])->name('images.store');

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -1,34 +1,42 @@
 <?php
 
+use Wink\Http\Controllers\ImageUploadsController;
+use Wink\Http\Controllers\LoginController;
+use Wink\Http\Controllers\PagesController;
+use Wink\Http\Controllers\PostsController;
+use Wink\Http\Controllers\SPAViewController;
+use Wink\Http\Controllers\TagsController;
+use Wink\Http\Controllers\TeamController;
+
 // Blog Posts...
-Route::get('/api/posts', 'PostsController@index')->name('posts.index');
-Route::get('/api/posts/{id?}', 'PostsController@show')->name('posts.show');
-Route::post('/api/posts/{id}', 'PostsController@store')->name('posts.store');
-Route::delete('/api/posts/{id}', 'PostsController@delete')->name('posts.delete');
+Route::get('/api/posts', [PostsController::class, 'index'])->name('posts.index');
+Route::get('/api/posts/{id?}', [PostsController::class, 'show'])->name('posts.show');
+Route::post('/api/posts/{id}', [PostsController::class, 'store'])->name('posts.store');
+Route::delete('/api/posts/{id}', [PostsController::class, 'delete'])->name('posts.delete');
 
 // Blog Tags...
-Route::get('/api/tags', 'TagsController@index')->name('tags.index');
-Route::get('/api/tags/{id?}', 'TagsController@show')->name('tags.show');
-Route::post('/api/tags/{id}', 'TagsController@store')->name('tags.store');
-Route::delete('/api/tags/{id}', 'TagsController@delete')->name('tags.delete');
+Route::get('/api/tags', [TagsController::class, 'index'])->name('tags.index');
+Route::get('/api/tags/{id?}', [TagsController::class, 'show'])->name('tags.show');
+Route::post('/api/tags/{id}', [TagsController::class, 'store'])->name('tags.store');
+Route::delete('/api/tags/{id}', [TagsController::class, 'delete'])->name('tags.delete');
 
 // Blog Authors...
-Route::get('/api/team', 'TeamController@index')->name('team.index');
-Route::get('/api/team/{id?}', 'TeamController@show')->name('team.show');
-Route::post('/api/team/{id}', 'TeamController@store')->name('team.store');
-Route::delete('/api/team/{id}', 'TeamController@delete')->name('team.delete');
+Route::get('/api/team', [TeamController::class, 'index'])->name('team.index');
+Route::get('/api/team/{id?}', [TagsController::class, 'show'])->name('team.show');
+Route::post('/api/team/{id}', [TagsController::class, 'store'])->name('team.store');
+Route::delete('/api/team/{id}', [TagsController::class, 'delete'])->name('team.delete');
 
 // Blog Image Uploads
-Route::post('/api/uploads', 'ImageUploadsController@upload')->name('images.store');
+Route::post('/api/uploads', [ImageUploadsController::class, 'upload'])->name('images.store');
 
 // Blog Pages...
-Route::get('/api/pages', 'PagesController@index')->name('pages.index');
-Route::get('/api/pages/{id?}', 'PagesController@show')->name('pages.show');
-Route::post('/api/pages/{id}', 'PagesController@store')->name('pages.store');
-Route::delete('/api/pages/{id}', 'PagesController@delete')->name('pages.delete');
+Route::get('/api/pages', [PagesController::class, 'index'])->name('pages.index');
+Route::get('/api/pages/{id?}', [PagesController::class, 'show'])->name('pages.show');
+Route::post('/api/pages/{id}', [PagesController::class, 'store'])->name('pages.store');
+Route::delete('/api/pages/{id}', [PagesController::class, 'delete'])->name('pages.delete');
 
 // Logout Route...
-Route::get('/logout', 'LoginController@logout')->name('logout');
+Route::get('/logout', [LoginController::class, 'logout'])->name('logout');
 
 // Catch-all Route...
-Route::get('/{view?}', 'SPAViewController')->name('spa')->where('view', '(.*)');
+Route::get('/{view?}', SPAViewController::class)->name('spa')->where('view', '(.*)');

--- a/src/WinkServiceProvider.php
+++ b/src/WinkServiceProvider.php
@@ -4,6 +4,8 @@ namespace Wink;
 
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use Wink\Http\Controllers\ForgotPasswordController;
+use Wink\Http\Controllers\LoginController;
 use Wink\Http\Middleware\Authenticate;
 
 class WinkServiceProvider extends ServiceProvider
@@ -33,22 +35,20 @@ class WinkServiceProvider extends ServiceProvider
     {
         $middlewareGroup = config('wink.middleware_group');
 
-        Route::namespace('Wink\Http\Controllers')
-            ->middleware($middlewareGroup)
+        Route::middleware($middlewareGroup)
             ->as('wink.')
             ->domain(config('wink.domain'))
             ->prefix(config('wink.path'))
             ->group(function () {
-                Route::get('/login', 'LoginController@showLoginForm')->name('auth.login');
-                Route::post('/login', 'LoginController@login')->name('auth.attempt');
+                Route::get('/login', [LoginController::class, 'showLoginForm'])->name('auth.login');
+                Route::post('/login', [LoginController::class, 'login'])->name('auth.attempt');
 
-                Route::get('/password/forgot', 'ForgotPasswordController@showResetRequestForm')->name('password.forgot');
-                Route::post('/password/forgot', 'ForgotPasswordController@sendResetLinkEmail')->name('password.email');
-                Route::get('/password/reset/{token}', 'ForgotPasswordController@showNewPassword')->name('password.reset');
+                Route::get('/password/forgot', [ForgotPasswordController::class, 'showResetRequestForm'])->name('password.forgot');
+                Route::post('/password/forgot', [ForgotPasswordController::class, 'sendResetLinkEmail'])->name('password.email');
+                Route::get('/password/reset/{token}', [ForgotPasswordController::class, 'showNewPassword'])->name('password.reset');
             });
 
-        Route::namespace('Wink\Http\Controllers')
-            ->middleware([$middlewareGroup, Authenticate::class])
+        Route::middleware([$middlewareGroup, Authenticate::class])
             ->as('wink.')
             ->domain(config('wink.domain'))
             ->prefix(config('wink.path'))


### PR DESCRIPTION
This PR updates the `laravel/framework` dependency to work with either Laravel 7 or 8. 

The default route namespace has been removed from the `WinkServiceProvider`. All controller declarations have been updated to use the standard PHP callable syntax.